### PR TITLE
PHP Errors fixed in metabox

### DIFF
--- a/includes/modules/learndash.php
+++ b/includes/modules/learndash.php
@@ -46,7 +46,9 @@ class PMPro_Courses_LearnDash extends PMPro_Courses_Module {
 	 * Add Require Membership box to LearnDash courses.
 	 */
 	public static function admin_menu() {
-		add_meta_box( 'pmpro_page_meta', __( 'Require Membership', 'pmpro-courses' ), 'pmpro_page_meta', 'sfwd-courses', 'side');
+		if( function_exists( 'pmpro_page_meta' ) ){
+			add_meta_box( 'pmpro_page_meta', __( 'Require Membership', 'pmpro-courses' ), 'pmpro_page_meta', 'sfwd-courses', 'side');
+		}
 	}
 
 	/**

--- a/includes/modules/lifterlms.php
+++ b/includes/modules/lifterlms.php
@@ -44,7 +44,9 @@ class PMPro_Courses_LifterLMS extends PMPro_Courses_Module {
 	 * Add Require Membership box to LearnDash courses.
 	 */
 	public static function admin_menu() {
-		add_meta_box( 'pmpro_page_meta', __( 'Require Membership', 'pmpro-courses' ), 'pmpro_page_meta', 'course', 'side');
+		if( function_exists( 'pmpro_page_meta' ) ){
+			add_meta_box( 'pmpro_page_meta', __( 'Require Membership', 'pmpro-courses' ), 'pmpro_page_meta', 'course', 'side');
+		}
 	}
 		
 	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

PHP error in metabox on course edit pages have been fixed for LifterLMS and LearnDash - 

### How to test the changes in this Pull Request:

1. Deactivate PMPro
2. Edit the course
3. No error or meta box for Require Memberships should show up

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

PHP errors fixed
