### PR TITLE
Fixed warning when using shortcode.

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -146,7 +146,7 @@ function pmpro_courses_get_courses_html( $courses ) {
 								$lesson_count = pmpro_courses_get_lesson_count( $course->ID );
 								if ( ! empty( $lesson_count ) ) { ?>
 								<span class="pmpro_courses-course-lesson-count">
-									<?php printf( esc_html( _n( '%s Lesson', '%s Lessons', $lesson_count, 'pmpro-courses' ), number_format_i18n( $lesson_count ) ) ); ?>
+								<?php printf( esc_html( _n( '%s Lesson', '%s Lessons', $lesson_count, 'pmpro-courses' ) ), number_format_i18n( $lesson_count ) ); ?>
 								</span>
 							<?php } ?>
 						</a>


### PR DESCRIPTION
BUG FIX: Fixed an issue where lesson count wasn't showing inside both shortcodes. (printf too few arguments).

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

BUG FIX: Fixed an issue where lesson count wasn't showing inside both shortcodes. (printf too few arguments).
