### PR TITLE
Admin CSS fix; Translations; Version bump and tested up to WP 5.9

### DIFF
--- a/.github/workflows/generate-translations.yml
+++ b/.github/workflows/generate-translations.yml
@@ -1,0 +1,18 @@
+name: Generate Translations
+on: workflow_dispatch
+jobs:
+  generate-translations:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: WordPress POT/PO/MO Generator
+      uses: strangerstudios/action-wp-pot-po-mo-generator@main
+      with:
+        generate_pot: 1
+        generate_po: 1
+        generate_mo: 1
+        generate_lang_packs: 1
+        merge_changes: 1
+        headers: '{"Report-Msgid-Bugs-To":"info@paidmembershipspro.com","Last-Translator":"Paid Memberships Pro <info@paidmembershipspro.com>","Language-Team":"Paid Memberships Pro <info@paidmembershipspro.com>"}'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/css/admin.css
+++ b/css/admin.css
@@ -11,7 +11,7 @@ table.pmpro-metabox-items {
 table.pmpro-metabox-items thead tr th {
 	background: #ccd0d4;
 	font-weight: bold;
-	padding: 5px;
+	padding: 8px 10px;
 	text-align: left;
 }
 table.pmpro-metabox-items tbody tr td label {

--- a/includes/common.php
+++ b/includes/common.php
@@ -146,7 +146,7 @@ function pmpro_courses_get_courses_html( $courses ) {
 								$lesson_count = pmpro_courses_get_lesson_count( $course->ID );
 								if ( ! empty( $lesson_count ) ) { ?>
 								<span class="pmpro_courses-course-lesson-count">
-								<?php printf( esc_html( _n( '%s Lesson', '%s Lessons', $lesson_count, 'pmpro-courses' ) ), number_format_i18n( $lesson_count ) ); ?>
+									<?php printf( esc_html( _n( '%s Lesson', '%s Lessons', $lesson_count, 'pmpro-courses' ) ), number_format_i18n( $lesson_count ) ); ?>
 								</span>
 							<?php } ?>
 						</a>

--- a/pmpro-courses.php
+++ b/pmpro-courses.php
@@ -3,7 +3,7 @@
  * Plugin Name: Paid Memberships Pro - Courses for Membership Add On
  * Plugin URI: https://www.paidmembershipspro.com/add-ons/pmpro-courses-lms-integration/
  * Description: Create courses and lessons for members. Integrates LMS plugins with Paid Memberships Pro.
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author: Paid Memberships Pro
  * Author URI: https://www.paidmembershipspro.com
  * Text Domain: pmpro-courses

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: strangerstudios, kimannwall, jarryd-long
 Tags: pmpro, membership, elearning, course, learning management system
 Requires at least: 5.4
-Tested up to: 5.8.2
-Stable tag: 1.0.4
+Tested up to: 5.9
+Stable tag: 1.0.5
 Requires PHP: 5.6
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -83,14 +83,21 @@ Please visit [our support site at https://www.paidmembershipspro.com](http://www
 4. A course page on the site frontend showing overview content, a registration box with required levels, and a list of lessons.
 
 == Changelog ==
-= 1.0.4 - 2021-12-23
+
+= 1.0.5 - 2022-01-30 =
+* BUG FIX: Fixed an issue where lesson count wasn't showing inside both shortcodes. (printf too few arguments).
+* ENHANCEMENT: Improved padding for table header cells to match .widefat td in the lessons metabox.
+* ENHANCEMENT: Added the WP POT/PO/MO Generator action for localizing.
+* ENHANCEMENT: Tested up to WordPress 5.9.
+
+= 1.0.4 - 2021-12-23 =
 * SECURITY: Added an additional permissions check before saving settings.
 
-= 1.0.3 - 2021-12-23
+= 1.0.3 - 2021-12-23 =
 * BUG FIX: Fixed issues with saving course module settings.
 * Now requiring PHP 5.6+ to match minimum requirements for Paid Memberships Pro.
 
-= 1.0.2 - 2021-07-23
+= 1.0.2 - 2021-07-23 =
 * BUG FIX: Fixed issues with saving lessons from the edit post page.
 
 = 1.0.1 - 2021-07-15 =

--- a/readme.txt
+++ b/readme.txt
@@ -84,7 +84,7 @@ Please visit [our support site at https://www.paidmembershipspro.com](http://www
 
 == Changelog ==
 
-= 1.0.5 - 2022-01-30 =
+= 1.0.5 - 2022-01-31 =
 * BUG FIX: Fixed an issue where lesson count wasn't showing inside both shortcodes. (printf too few arguments).
 * ENHANCEMENT: Improved padding for table header cells to match .widefat td in the lessons metabox.
 * ENHANCEMENT: Added the WP POT/PO/MO Generator action for localizing.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

* BUG FIX: Fixed an issue where lesson count wasn't showing inside both shortcodes. (printf too few arguments).
 * ENHANCEMENT: Improved padding for table header cells to match .widefat td in the lessons metabox.
 * ENHANCEMENT: Added the WP POT/PO/MO Generator action for localizing.
 * ENHANCEMENT: Tested up to WordPress 5.9.
