### PR TITLE
Improved logic for Tutor LMS lessons

### DIFF
--- a/includes/modules/tutorlms.php
+++ b/includes/modules/tutorlms.php
@@ -66,8 +66,15 @@ class PMPro_Courses_TutorLMS extends PMPro_Courses_Module {
 		// Only check if a TutorLMS CPT.
 		if ( ! empty( $post ) && is_singular( array( 'courses', 'topics', 'lesson', 'tutor_quiz' ) ) ) {
 
-			// Check access for this course or lesson.
-			$access = self::has_access_to_post( $post->ID );
+			// If lesson check grandparent (course) access
+			if ( is_singular( 'lesson' ) ) {
+				$topic = get_post( $post->post_parent );
+				$post_grand_parent = ! empty( $topic ) ? (int) $topic->post_parent : (int) $post->post_parent;
+
+				$access = self::has_access_to_post( $post_grand_parent );
+			} else {
+				$access = self::has_access_to_post( $post->ID );
+			}			
 
 			// They have access. Let them in.
 			if ( $access ) {


### PR DESCRIPTION
* BUG FIX: Fixed an issue where lessons were open due to checking the access to a topic ID and not the course ID (grandparent).

To add to this, I'm not sure if Tutor LMS had changed things but the issue was the structure of a lesson was nested within a topic. (i.e. Course A > Topic 1 > Lesson 1.1). Our code was checking if the user has access to a current post or not which would give access even if the course is restricted.

**Scenarios**

* Courses that were public would be open as soon as you're logged-in but had no membership level.
* Courses that were private (and free) would allow you to enroll and immediately get access to lessons (but course content would be restricted on the courses view).

This now restricts lessons as long as the member does not have access to the actual course "object". It will redirect back to the course main page until access is granted. _Fixes issues with the Approvals Add On_.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

