### PR TITLE
Fixed issue for fatal error ($new_links)

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -48,8 +48,10 @@ function pmpro_courses_plugin_action_links( $links ) {
 		$new_links = array(
 			'<a href="' . esc_url( get_admin_url( null, 'admin.php?page=pmpro-courses-settings' ) ) . '">' . esc_html__( 'Settings', 'pmpro-courses' ) . '</a>',
 		);
+
+		$links = array_merge( $new_links, $links );
 	}
-	return array_merge( $new_links, $links );
+	return $links;
 }
 add_filter( 'plugin_action_links_' . PMPRO_COURSES_BASENAME, 'pmpro_courses_plugin_action_links' );
 


### PR DESCRIPTION
Fix an issue for non-admins that can edit plugins. The $new_links didn't exist, causing a fatal error.

Resolves: https://github.com/strangerstudios/pmpro-courses/issues/38