### PR TITLE
Replace level URL with the checkout if only one level is selected

### DIFF
--- a/includes/courses.php
+++ b/includes/courses.php
@@ -16,6 +16,13 @@ function pmpro_courses_show_course_content_and_lessons( $filtered_content, $orig
 			$hasaccess = $hasaccess[0];
 			if ( ! $hasaccess ) {
 				$no_access_message = pmpro_get_no_access_message( '', $post_membership_levels_ids, $post_membership_levels_names );
+
+				// If there's only one level, let's replace the levels join now with the checkout URL.
+				if ( count( $post_membership_levels_ids ) == 1 ) {
+					$checkout_link = pmpro_url( 'checkout', '?level=' . esc_attr( $post_membership_levels_ids[0] ) );
+					$levels_url = pmpro_url( 'levels' );
+					$no_access_message = str_replace( $levels_url, $checkout_link, $no_access_message );
+				}
 			}
 		}
 

--- a/includes/courses.php
+++ b/includes/courses.php
@@ -17,7 +17,7 @@ function pmpro_courses_show_course_content_and_lessons( $filtered_content, $orig
 			if ( ! $hasaccess ) {
 				$no_access_message = pmpro_get_no_access_message( '', $post_membership_levels_ids, $post_membership_levels_names );
 
-				// If there's only one level, let's replace the levels join now with the checkout URL.
+				// If there's only one level, let's replace the levels URL with the checkout URL.
 				if ( count( $post_membership_levels_ids ) == 1 ) {
 					$checkout_link = pmpro_url( 'checkout', '?level=' . esc_attr( $post_membership_levels_ids[0] ) );
 					$levels_url = pmpro_url( 'levels' );


### PR DESCRIPTION
* ENHANCEMENT: Replace the levels page URL with the checkout URL if only one level is assigned to the page.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?