### PR TITLE
Changes to the Add to Course button when adding a lesson

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -90,6 +90,8 @@ function pmpro_courses_setup() {
 	
 	jQuery('#pmpro_courses_save').click(function() {
 		if( jQuery(this).attr('disabled') !== 'true' ){
+			//Show that the courses is being 
+			jQuery( this ).html( pmpro_courses.adding );
 			pmpro_courses_update_post();
 		}
 	});

--- a/pmpro-courses.php
+++ b/pmpro-courses.php
@@ -112,6 +112,7 @@ function pmpro_courses_admin_styles( $hook ) {
 			'course_id'      => $post_id,
 			'save'           => esc_html__( 'Save', 'pmpro-courses' ),
 			'saving'         => esc_html__( 'Saving...', 'pmpro-courses' ),
+			'adding'         => esc_html__( 'Adding...', 'pmpro-courses' ),
 			'saving_error_1' => esc_html__( 'Error saving lesson [1]', 'pmpro-courses' ),
 			'saving_error_2' => esc_html__( 'Error saving lesson [2]', 'pmpro-courses' ),
 			'remove_error_1' => esc_html__( 'Error removing lesson [1]', 'pmpro-courses' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the 'Add to Course' button when adding a new lesson to the course to 'Adding...'. 

Once the lesson has been added, the button resets automatically. 

This should help with cases adding could take noticeably longer on larger sites. 

### How to test the changes in this Pull Request:

1. Navigate to Courses and Add new or Edit an existing one
2. Scroll down to the Lessons meta box and select a lesson
3. Click Add to Course. This value will change to Adding... before being reset back to Add to Course

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

We now indicate in the Add to Course button that the course is being added
