### PR TITLE
PMPro Courses, TutorLMS “preview” lessons.

### DIFF
--- a/includes/modules/tutorlms.php
+++ b/includes/modules/tutorlms.php
@@ -71,7 +71,7 @@ class PMPro_Courses_TutorLMS extends PMPro_Courses_Module {
 				$topic = get_post( $post->post_parent );
 				$post_grand_parent = ! empty( $topic ) ? (int) $topic->post_parent : (int) $post->post_parent;
 
-				$access = self::has_access_to_post( $post_grand_parent );
+				$access = get_post_meta( $post->ID, '_is_preview', true ) || self::has_access_to_post( $post_grand_parent );
 			} else {
 				$access = self::has_access_to_post( $post->ID );
 			}			

--- a/includes/post-types/courses.php
+++ b/includes/post-types/courses.php
@@ -11,7 +11,7 @@ function pmpro_courses_course_cpt() {
 	 * If there is a collision, append a -2 to the slug.
 	 * 
 	 * @return string $rewrite_slug
-	 * @since TBD
+	 * @since 1.2.2
 	 */
 	function check_for_collision() {
 		$post_types = $GLOBALS['wp_post_types'];

--- a/includes/post-types/courses.php
+++ b/includes/post-types/courses.php
@@ -5,6 +5,26 @@
  */
 function pmpro_courses_course_cpt() {
 
+
+	/**
+	 * Check for collisions with other post types.
+	 * If there is a collision, append a -2 to the slug.
+	 * 
+	 * @return string $rewrite_slug
+	 * @since TBD
+	 */
+	function check_for_collision() {
+		$post_types = $GLOBALS['wp_post_types'];
+		foreach ( $post_types as $post_type ) {
+			if ( $post_type->rewrite && $post_type->rewrite['slug'] === 'course' ) {
+				return $post_type->rewrite['slug'] . "-2";
+			}
+		}
+		return  "course";
+	}
+	$rewrite_slug = check_for_collision();
+
+
 	$labels  = array(
 		'name'                  => esc_html_x( 'Courses', 'Post Type General Name', 'pmpro-courses' ),
 		'singular_name'         => esc_html_x( 'Course', 'Post Type Singular Name', 'pmpro-courses' ),
@@ -34,7 +54,7 @@ function pmpro_courses_course_cpt() {
 		'filter_items_list'     => esc_html__( 'Filter Courses list', 'pmpro-courses' ),
 	);
 	$rewrite = array(
-		'slug'       => 'course',
+		'slug'       => $rewrite_slug,
 		'with_front' => true,
 		'pages'      => true,
 		'feeds'      => false,
@@ -74,7 +94,7 @@ function pmpro_courses_course_cpt() {
 	    )
  	);
 }
-add_action( 'init', 'pmpro_courses_course_cpt', 0 );
+add_action( 'init', 'pmpro_courses_course_cpt', 30 );
 
 /**
  * Define the metaboxes.

--- a/pmpro-courses.php
+++ b/pmpro-courses.php
@@ -3,7 +3,7 @@
  * Plugin Name: Paid Memberships Pro - Courses for Membership Add On
  * Plugin URI: https://www.paidmembershipspro.com/add-ons/pmpro-courses-lms-integration/
  * Description: Create courses and lessons for members. Integrates LMS plugins with Paid Memberships Pro.
- * Version: 1.2.1
+ * Version: 1.2.2
  * Author: Paid Memberships Pro
  * Author URI: https://www.paidmembershipspro.com
  * Text Domain: pmpro-courses

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios, paidmembershipspro, kimannwall, jarryd-long
 Tags: course, education, elearning, lms, membership, pmpro
 Requires at least: 5.4
 Tested up to: 6.2
-Stable tag: 1.2
+Stable tag: 1.2.2
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -135,6 +135,11 @@ Please visit [our support site at https://www.paidmembershipspro.com](http://www
 4. A course page on the site frontend showing overview content, a registration box with required levels, and a list of lessons.
 
 == Changelog ==
+
+= 1.2.2 - 2023-06-28 =
+* BUG FIX: Fixed and issue with TutorLMS integration. Clicking Preview lesson button was causing redirect instead of actually preview the lesson.
+* BUG FIX: Fixed an issue with default and LifterLMS modules enabled at the same time. LifterLMS courses were giving 404 errors due conflicts with default CPT and Lifter permalinks.
+
 = 1.2.1 - 2023-01-19 =
 * ENHANCEMENT: If a course requires only one membership level, redirect directly to the checkout for that level instead of the level select page.
 * ENHANCEMENT: Added a small hint when adding a lesson to a course to indicate the lesson is being added to the course.


### PR DESCRIPTION
 * Check if the lesson is a "preview" lesson before check if the course requires membership access

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?


### Changes proposed in this Pull Request:

Added further check to bypass preview lessons before check if the user has access to a  course.

Resolves XXX.

### How to test the changes in this Pull Request:

1. Install Tutor LMS
2. Install Tutor LMS Pro
3. Install Preview Tutor Add On 
4. Install PMPPro course Add On and check Tutor LMS setting 
5. Create a private Tutor course and make it required for certain membership level.
6. Add few lessons,  make one preview.
7.  Open an incognito window and without login navigate to the course
8.  Click the link to the lesson with eye icon (preview one)
9. Check if you can see the lesson of you're redirected to the Course page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* BUG FIX:  Fixed and issue with TutorLMS integration. Clicking Preview lesson button was causing redirect instead of actually preview the lesson. 
* BUG FIX: Fixed an issue with default and LifterLMS modules enabled at the same time. LifterLMS courses were giving 404 errors due conflicts with default CPT and Lifter permalinks.
