### PR TITLE
Abstracting the rewrite slug creation for our courses and lessons CPTs to support running alongside other LMS plugins.

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -42,3 +42,11 @@ table#newmeta tbody tr td a.button {
 table#newmeta {
 	margin-bottom: 1em;
 }
+
+/* Settings Form*/
+.form-table.pmpro-courses, .form-table.pmpro-courses tr.pmpro-courses-default, .form-table.pmpro-courses tr.pmpro-courses-lifterlms {
+	border-bottom: 1px solid #CCC;
+}
+.pmpro-courses-module-settings {
+	margin-top: 1em;
+}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -3,15 +3,37 @@
  * Runs only when the plugin is activated.
  *
  * @since 0.1.0
+ * @since 1.2.2 Changed name. Flushing rewrite rules when other plugins are activated too.
  */
-function pmpro_courses_admin_notice_activation_hook() {
-	// Create transient data.
-	set_transient( 'pmpro-courses-admin-notice', true, 5 );
+function pmpro_courses_activation() {
+	// If this plugin is being acitvated, show a notice.
+	if ( current_filter() === 'activate_' . PMPRO_COURSES_BASENAME ) {
+		set_transient( 'pmpro-courses-admin-notice', true, 5 );
+	}
 	
 	// Trigger a rewrite rule flush in case the default module is on.
 	set_transient( 'pmpro_courses_flush_rewrite_rules', 1 );
 }
-register_activation_hook( PMPRO_COURSES_BASENAME, 'pmpro_courses_admin_notice_activation_hook' );
+register_activation_hook( PMPRO_COURSES_BASENAME, 'pmpro_courses_activation' );
+register_activation_hook( 'lifterlms/lifterlms.php', 'pmpro_courses_activation' );
+register_activation_hook( 'tutor/tutor.php', 'pmpro_courses_activation' );
+register_activation_hook( 'sensei-lms/lsensei-lms.php', 'pmpro_courses_activation' );
+register_activation_hook( 'sfwd-lms/sfwd_lms.php', 'pmpro_courses_activation' );
+
+/**
+ * Runs only when the plugin is deactivated.
+ *
+ * @since 1.2.2
+ */
+function pmpro_courses_deactivation() {
+	// Trigger a rewrite rule flush in case the default module is on.
+	set_transient( 'pmpro_courses_flush_rewrite_rules', 1 );
+}
+register_deactivation_hook( PMPRO_COURSES_BASENAME, 'pmpro_courses_deactivation' );
+register_deactivation_hook( 'lifterlms/lifterlms.php', 'pmpro_courses_deactivation' );
+register_deactivation_hook( 'tutor/tutor.php', 'pmpro_courses_deactivation' );
+register_deactivation_hook( 'sensei-lms/lsensei-lms.php', 'pmpro_courses_deactivation' );
+register_deactivation_hook( 'sfwd-lms/sfwd_lms.php', 'pmpro_courses_deactivation' );
 
 /**
  * Admin Notice on Activation.

--- a/includes/adminpages/settings.php
+++ b/includes/adminpages/settings.php
@@ -7,7 +7,7 @@
 	<p><?php esc_html_e( 'Which modules would you like to enable?', 'pmpro-courses' ); ?></p>
 	<form method='POST'>
 		<h3><?php esc_html_e( 'Modules', 'pmpro-courses' );?></h3>
-		<table class='form-table'>	
+		<table class='form-table pmpro-courses'>	
 		<?php
 			$modules = pmpro_courses_get_modules();            
             if( !empty( $modules ) ){
@@ -27,7 +27,7 @@
 						),
 					);
 					?>
-					<tr>
+					<tr class="pmpro-courses-<?php echo esc_attr( $module['slug'] );?>">
 						<th scope="row" valign="top">
 							<label for="<?php echo esc_attr( $module['slug'] ); ?>"><?php echo esc_html( $module['name'] ); ?></label>
 						</th>
@@ -35,6 +35,9 @@
                             <input type='checkbox' name='pmpro_courses_modules[]' value='<?php echo esc_attr( $module['slug'] ); ?>' id='<?php echo esc_attr( $module['slug'] ); ?>' <?php if( $checked ){ echo 'checked="true"'; } ?>/>
                             <label for="<?php echo esc_attr( $module['slug'] ); ?>"><?php echo esc_html( $module['title'] );?></label>
                             <p class="description"><?php echo wp_kses( $module['description'], $allowed_module_description_html ); ?></p>
+							<?php
+								do_action( 'pmpro_courses_module_settings', $module );
+							?>
                         </td>
 					</tr>
 					<?php

--- a/includes/common.php
+++ b/includes/common.php
@@ -268,3 +268,38 @@ function pmpro_courses_get_lessons_html( $course_id ) {
 
 	return $lessons_html;
 }
+
+/**
+ * Get a unique rewrite slug for our CPTs.
+ */
+function pmpro_courses_unique_rewrite_slug( $slug ) {
+	global $wp_post_types;
+
+	$suffix = 0;
+	do	{
+		$check_for_collision = false;
+		foreach( $wp_post_types as $post_type ) {
+			// Make sure rewrite values are there.
+			if ( empty( $post_type->rewrite ) ) {
+				continue;
+			}
+			if ( empty( $post_type->rewrite['slug'] ) ) {
+				continue;
+			}
+			
+			// Is our slug already taken?
+			if ( ! empty( $suffix ) ) {
+				$new_slug = $slug . '-' . $suffix;
+			} else {
+				$new_slug = $slug;
+			}
+			if ( $post_type->rewrite['slug'] === $new_slug ) {
+				$suffix = max( 2, $suffix + 1 );	// Start at 2. Increment suffix.
+				$check_for_collision = true;		// Check again.
+				break;
+			}
+		}
+	} while( $check_for_collision );
+
+	return $new_slug;
+}

--- a/includes/modules/default.php
+++ b/includes/modules/default.php
@@ -44,6 +44,7 @@ class PMPro_Courses_Module {
 
         // Hooks we always want to run.
         add_action( 'pmpro_courses_module_settings', array( 'PMPro_Courses_Module', 'admin_settings' ) );
+        add_action( 'pmpro_courses_settings_save', array( 'PMPro_Courses_Module', 'admin_settings_save' ) );
     }
     
     /**
@@ -103,6 +104,19 @@ class PMPro_Courses_Module {
     }
 
     /**
+     * Save additional admin settings.
+     * @since 1.2.2
+     */
+    static public function admin_settings_save() {
+        // Save settings.
+        if ( ! empty( $_REQUEST['pmpro_courses_cpt_archive'] ) ) {
+            update_option( 'pmpro_courses_cpt_archive', true );
+        } else {
+            update_option( 'pmpro_courses_cpt_archive', false );
+        }
+    }
+
+    /**
      * Additional admin settings.
      * @since 1.2.2
      */
@@ -111,20 +125,8 @@ class PMPro_Courses_Module {
             return;
         }
 
-        // Save settings or get from options.
-        if ( ! empty( $_REQUEST['pmpro_courses_save_settings'] ) ) {
-            // Save settings.
-            if ( ! empty( $_REQUEST['pmpro_courses_cpt_archive'] ) ) {
-                update_option( 'pmpro_courses_cpt_archive', true );
-                $cpt_archive = true;
-            } else {
-                update_option( 'pmpro_courses_cpt_archive', false );
-                $cpt_archive = false;
-            }
-        } else {
-            // Get settings from options.
-            $cpt_archive = get_option( 'pmpro_courses_cpt_archive', false );
-        }
+        // Get settings from options.
+        $cpt_archive = get_option( 'pmpro_courses_cpt_archive', false );
 
         // Show settings.
         ?>

--- a/includes/modules/default.php
+++ b/includes/modules/default.php
@@ -110,9 +110,9 @@ class PMPro_Courses_Module {
     static public function admin_settings_save() {
         // Save settings.
         if ( ! empty( $_REQUEST['pmpro_courses_cpt_archive'] ) ) {
-            update_option( 'pmpro_courses_cpt_archive', true );
+            update_option( 'pmpro_courses_cpt_archive', 1 );
         } else {
-            update_option( 'pmpro_courses_cpt_archive', false );
+            update_option( 'pmpro_courses_cpt_archive', 0 );
         }
     }
 
@@ -126,12 +126,12 @@ class PMPro_Courses_Module {
         }
 
         // Get settings from options.
-        $cpt_archive = get_option( 'pmpro_courses_cpt_archive', false );
+        $cpt_archive = get_option( 'pmpro_courses_cpt_archive', 1 );
 
         // Show settings.
         ?>
         <div class="pmpro-courses-module-settings pmpro-courses-default-settings" data-module="default">
-            <input type='checkbox' name='pmpro_courses_cpt_archive' value='1' id='pmpro_courses_cpt_archive' <?php checked( $cpt_archive, true ); ?> />
+            <input type='checkbox' name='pmpro_courses_cpt_archive' value='1' id='pmpro_courses_cpt_archive' <?php checked( $cpt_archive, 1 ); ?> />
             <label for="pmpro_courses_cpt_archive"><?php esc_html_e( 'Enable Archive Page for the Default Courses CPT?', 'pmpro-courses' );?></label>
         </div>
         <?php

--- a/includes/modules/default.php
+++ b/includes/modules/default.php
@@ -41,6 +41,9 @@ class PMPro_Courses_Module {
         if ( $this->is_active() ) {
             $this->init_active();
         }
+
+        // Hooks we always want to run.
+        add_action( 'pmpro_courses_module_settings', array( 'PMPro_Courses_Module', 'admin_settings' ) );
     }
     
     /**
@@ -96,6 +99,39 @@ class PMPro_Courses_Module {
         require_once PMPRO_COURSES_DIR . '/includes/shortcodes/my-courses.php';
                 
         add_filter( 'pmpro_membership_content_filter', 'pmpro_courses_show_course_content_and_lessons', 10, 2 );
-        add_filter( 'the_content', 'pmpro_courses_add_lessons_to_course' );        
+        add_filter( 'the_content', 'pmpro_courses_add_lessons_to_course' );
+    }
+
+    /**
+     * Additional admin settings.
+     * @since 1.2.2
+     */
+    static public function admin_settings( $module ) {
+        if ( empty( $module ) || $module['slug'] !== 'default' ) {
+            return;
+        }
+
+        // Save settings or get from options.
+        if ( ! empty( $_REQUEST['pmpro_courses_save_settings'] ) ) {
+            // Save settings.
+            if ( ! empty( $_REQUEST['pmpro_courses_cpt_archive'] ) ) {
+                update_option( 'pmpro_courses_cpt_archive', true );
+                $cpt_archive = true;
+            } else {
+                update_option( 'pmpro_courses_cpt_archive', false );
+                $cpt_archive = false;
+            }
+        } else {
+            // Get settings from options.
+            $cpt_archive = get_option( 'pmpro_courses_cpt_archive', false );
+        }
+
+        // Show settings.
+        ?>
+        <div class="pmpro-courses-module-settings pmpro-courses-default-settings" data-module="default">
+            <input type='checkbox' name='pmpro_courses_cpt_archive' value='1' id='pmpro_courses_cpt_archive' <?php checked( $cpt_archive, true ); ?> />
+            <label for="pmpro_courses_cpt_archive"><?php esc_html_e( 'Enable Archive Page for the Default Courses CPT?', 'pmpro-courses' );?></label>
+        </div>
+        <?php
     }
 }

--- a/includes/post-types/courses.php
+++ b/includes/post-types/courses.php
@@ -4,27 +4,6 @@
  * Hooks into init.
  */
 function pmpro_courses_course_cpt() {
-
-
-	/**
-	 * Check for collisions with other post types.
-	 * If there is a collision, append a -2 to the slug.
-	 * 
-	 * @return string $rewrite_slug
-	 * @since 1.2.2
-	 */
-	function check_for_collision() {
-		$post_types = $GLOBALS['wp_post_types'];
-		foreach ( $post_types as $post_type ) {
-			if ( $post_type->rewrite && $post_type->rewrite['slug'] === 'course' ) {
-				return $post_type->rewrite['slug'] . "-2";
-			}
-		}
-		return  "course";
-	}
-	$rewrite_slug = check_for_collision();
-
-
 	$labels  = array(
 		'name'                  => esc_html_x( 'Courses', 'Post Type General Name', 'pmpro-courses' ),
 		'singular_name'         => esc_html_x( 'Course', 'Post Type Singular Name', 'pmpro-courses' ),
@@ -54,7 +33,7 @@ function pmpro_courses_course_cpt() {
 		'filter_items_list'     => esc_html__( 'Filter Courses list', 'pmpro-courses' ),
 	);
 	$rewrite = array(
-		'slug'       => $rewrite_slug,
+		'slug'       => pmpro_courses_unique_rewrite_slug( 'course' ),
 		'with_front' => true,
 		'pages'      => true,
 		'feeds'      => false,

--- a/includes/post-types/courses.php
+++ b/includes/post-types/courses.php
@@ -52,7 +52,7 @@ function pmpro_courses_course_cpt() {
 		'show_in_admin_bar'   => true,
 		'show_in_nav_menus'   => true,
 		'can_export'          => true,
-		'has_archive'         => 'courses',
+		'has_archive'         => get_option( 'pmpro_courses_cpt_archive', false ) ? 'courses' : false,
 		'exclude_from_search' => false,
 		'publicly_queryable'  => true,
 		'rewrite'             => $rewrite,

--- a/includes/post-types/courses.php
+++ b/includes/post-types/courses.php
@@ -52,7 +52,7 @@ function pmpro_courses_course_cpt() {
 		'show_in_admin_bar'   => true,
 		'show_in_nav_menus'   => true,
 		'can_export'          => true,
-		'has_archive'         => get_option( 'pmpro_courses_cpt_archive', false ) ? 'courses' : false,
+		'has_archive'         => get_option( 'pmpro_courses_cpt_archive', 1 ) ? 'courses' : false,
 		'exclude_from_search' => false,
 		'publicly_queryable'  => true,
 		'rewrite'             => $rewrite,

--- a/includes/post-types/lessons.php
+++ b/includes/post-types/lessons.php
@@ -35,7 +35,7 @@ function pmpro_courses_lesson_cpt() {
 		'filter_items_list'     => esc_html__( 'Filter Lessons list', 'pmpro-courses' ),
 	);
 	$rewrite = array(
-		'slug'       => 'lesson',
+		'slug'       => pmpro_courses_unique_rewrite_slug( 'lesson' ),
 		'with_front' => true,
 		'pages'      => true,
 		'feeds'      => false,

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -58,6 +58,9 @@ function pmpro_courses_settings_save() {
 		update_option( 'pmpro_courses_modules', [] );
 	}
 
+	// Save module specific settings.
+	do_action( 'pmpro_courses_settings_save' );
+
 	// Flush rewrite rules in case core module was activated/deactivated.
 	set_transient( 'pmpro_courses_flush_rewrite_rules', 1 );
 }

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -9,7 +9,7 @@
  */
 function pmpro_courses_settings_page() {
 	// Course settings page under Memberships menu.
-	add_submenu_page( 'pmpro-dashboard', esc_html__('Paid Memberships Pro Courses - Settings', 'pmpro-courses'), esc_html__('Courses', 'pmpro-courses'), 'manage_options', 'pmpro-courses-settings', 'pmpro_courses_settings' );
+	add_submenu_page( 'pmpro-dashboard', esc_html__('Paid Memberships Pro Courses - Settings', 'pmpro-courses'), esc_html__('Course Settings', 'pmpro-courses'), 'manage_options', 'pmpro-courses-settings', 'pmpro_courses_settings' );
 
 	if ( pmpro_courses_is_module_active( 'default' ) ) {
 		// Add New Lesson menu page under Courses menu.
@@ -59,7 +59,7 @@ function pmpro_courses_settings_save() {
 	}
 
 	// Flush rewrite rules in case core module was activated/deactivated.
-	set_transient( 'pmpro_courses_flush_rewrite_rules', 1 );	
+	set_transient( 'pmpro_courses_flush_rewrite_rules', 1 );
 }
 add_action( 'admin_init', 'pmpro_courses_settings_save' );
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -78,25 +78,58 @@ function pmpro_courses_update_post() {
 	});
 }
 
+/**
+ * Toggle the additional settings for a module.
+ */
+function pmpro_courses_toggle_module_settings(module) {
+	$module_tr = jQuery('tr.pmpro-courses-' + module);
+	$module_toggle = $module_tr.find('input[name="pmpro_courses_modules[]"]');
+	$module_settings = $module_tr.find('.pmpro-courses-module-settings');
+	if ( $module_toggle.is(':checked') ) {
+		$module_settings.show();
+	} else {
+		$module_settings.hide();
+	}
+}
+
 function pmpro_courses_setup() {
-	jQuery('#pmpro_courses_post').select2({width: 'elements'});
+	console.log( pmpro_courses );
 	
-	jQuery('#pmpro_courses_order').keypress(function (e) {
-		if (e.which == 13) {
-			pmpro_courses_update_post();
-			return false;
-		}
-	});
-	
-	jQuery('#pmpro_courses_save').click(function() {
-		if( jQuery(this).attr('disabled') !== 'true' ){
-			//Show that the courses is being 
-			jQuery( this ).html( pmpro_courses.adding );
-			pmpro_courses_update_post();
-		}
-	});
+	// Editing a course.
+	if ( pmpro_courses.editing_course ) {
+		jQuery('#pmpro_courses_post').select2({width: 'elements'});
+		
+		jQuery('#pmpro_courses_order').keypress(function (e) {
+			if (e.which == 13) {
+				pmpro_courses_update_post();
+				return false;
+			}
+		});
+		
+		jQuery('#pmpro_courses_save').click(function() {
+			if( jQuery(this).attr('disabled') !== 'true' ){
+				//Show that the courses is being 
+				jQuery( this ).html( pmpro_courses.adding );
+				pmpro_courses_update_post();
+			}
+		});
+	}
+
+	// Courses Settings page.
+	if ( pmpro_courses.on_settings_page ) {
+		// Hide module settings.
+		$module_settings = jQuery('.pmpro-courses-module-settings');
+		$module_settings.each(function() {
+			$module_name = $module_settings.attr('data-module');
+			$module_trigger = jQuery('input[name="pmpro_courses_modules[]"][value="' + $module_name + '"]');
+			$module_trigger.bind('click change', function() {
+				pmpro_courses_toggle_module_settings( $module_name );
+			});
+			pmpro_courses_toggle_module_settings( $module_name );
+		});
+	}
 }
 
 jQuery(document).ready(function(jQuery) {
-	pmpro_courses_setup();
+		pmpro_courses_setup();
 });

--- a/pmpro-courses.php
+++ b/pmpro-courses.php
@@ -97,7 +97,7 @@ function pmpro_courses_admin_styles( $hook ) {
 	$editing_course = in_array( $hook, array( 'post.php', 'post-new.php' ) ) && 'pmpro_course' == get_post_type();
 	$on_settings_page = ! empty( $_REQUEST['page'] ) && $_REQUEST['page'] === 'pmpro-courses-settings';
 
-	if ( $editin_course || $on_settings_page ) {
+	if ( $editing_course || $on_settings_page ) {
 
 		wp_enqueue_style( 'pmpro-courses-admin', plugins_url( 'css/admin.css', __FILE__ ), '', PMPRO_COURSES_VERSION, 'screen' );
 		wp_enqueue_style( 'pmpro-courses-select2', plugins_url( 'css/select2.css', __FILE__ ), '', PMPRO_COURSES_VERSION, 'screen' );

--- a/pmpro-courses.php
+++ b/pmpro-courses.php
@@ -26,10 +26,10 @@ require_once PMPRO_COURSES_DIR . '/includes/blocks.php';
 function pmpro_courses_setup_modules() {
 	require_once PMPRO_COURSES_DIR . '/includes/modules/default.php';
 	$default_module = new PMPro_Courses_Module();
-	require_once PMPRO_COURSES_DIR . '/includes/modules/learndash.php';
-	$learndash_module = new PMPro_Courses_LearnDash();
 	require_once PMPRO_COURSES_DIR . '/includes/modules/lifterlms.php';
 	$lifterlms_module = new PMPro_Courses_LifterLMS();
+	require_once PMPRO_COURSES_DIR . '/includes/modules/learndash.php';
+	$learndash_module = new PMPro_Courses_LearnDash();
 	require_once PMPRO_COURSES_DIR . '/includes/modules/senseilms.php';
 	$senseilms_module = new PMPro_Courses_SenseiLMS();
 	require_once PMPRO_COURSES_DIR . '/includes/modules/tutorlms.php';

--- a/pmpro-courses.php
+++ b/pmpro-courses.php
@@ -94,8 +94,10 @@ add_action( 'plugins_loaded', 'pmpro_courses_load_textdomain' );
  * Enqueue Admin Scripts and Styles
  */
 function pmpro_courses_admin_styles( $hook ) {
+	$editing_course = in_array( $hook, array( 'post.php', 'post-new.php' ) ) && 'pmpro_course' == get_post_type();
+	$on_settings_page = ! empty( $_REQUEST['page'] ) && $_REQUEST['page'] === 'pmpro-courses-settings';
 
-	if ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) && 'pmpro_course' == get_post_type() ) {
+	if ( $editin_course || $on_settings_page ) {
 
 		wp_enqueue_style( 'pmpro-courses-admin', plugins_url( 'css/admin.css', __FILE__ ), '', PMPRO_COURSES_VERSION, 'screen' );
 		wp_enqueue_style( 'pmpro-courses-select2', plugins_url( 'css/select2.css', __FILE__ ), '', PMPRO_COURSES_VERSION, 'screen' );
@@ -109,14 +111,16 @@ function pmpro_courses_admin_styles( $hook ) {
 		}
 
 		$localize = array(
-			'course_id'      => $post_id,
-			'save'           => esc_html__( 'Save', 'pmpro-courses' ),
-			'saving'         => esc_html__( 'Saving...', 'pmpro-courses' ),
-			'adding'         => esc_html__( 'Adding...', 'pmpro-courses' ),
-			'saving_error_1' => esc_html__( 'Error saving lesson [1]', 'pmpro-courses' ),
-			'saving_error_2' => esc_html__( 'Error saving lesson [2]', 'pmpro-courses' ),
-			'remove_error_1' => esc_html__( 'Error removing lesson [1]', 'pmpro-courses' ),
-			'remove_error_2' => esc_html__( 'Error removing lesson [2]', 'pmpro-courses' ),
+			'editing_course'   => $editing_course,
+			'on_settings_page' => $on_settings_page,
+			'course_id'        => $post_id,
+			'save'             => esc_html__( 'Save', 'pmpro-courses' ),
+			'saving'           => esc_html__( 'Saving...', 'pmpro-courses' ),
+			'adding'           => esc_html__( 'Adding...', 'pmpro-courses' ),
+			'saving_error_1'   => esc_html__( 'Error saving lesson [1]', 'pmpro-courses' ),
+			'saving_error_2'   => esc_html__( 'Error saving lesson [2]', 'pmpro-courses' ),
+			'remove_error_1'   => esc_html__( 'Error removing lesson [1]', 'pmpro-courses' ),
+			'remove_error_2'   => esc_html__( 'Error removing lesson [2]', 'pmpro-courses' ),
 		);
 
 		wp_localize_script( 'pmpro_courses', 'pmpro_courses', $localize );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The courses and lessons rewrite slugs will append a -2 (or later) if it conflicts with another LMS plugins rewrite slugs. This breaks URLs for CPTs, but I think is the right decision. Folks will mostly be moving from PMPro Courses to another LMS plugin, and want to give the full featured LMS plugin the slug it wants.

We will write gists to override this behavior. You can hook into the CPT creation for both CPTs and override the rewrite slug that way.

We also need to account for the archive page, e.g. /courses/ when using LifterLMS is a specific template page, but we also set that as the archive page for our CPT. Still figuring that out.

This PR also updates the activation callback to run when the other LMS plugins are activated to flush the rewrite rules. We also flush rewrite rules on deactivation now as well.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #50

### How to test the changes in this Pull Request:

1. Install PMPro Courses and LifterLMS
2. Create courses in both plugins.
3. Activate both modules in PMPro courses.
4. Navigate to both course permalinks.
5. The default module course should have a URL like /courses-2/yourslug/

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
