### PR TITLE
Fixing enrollments when using MMPU

### DIFF
--- a/includes/modules/learndash.php
+++ b/includes/modules/learndash.php
@@ -221,21 +221,17 @@ class PMPro_Courses_LearnDash extends PMPro_Courses_Module {
 		if ( empty( $level_ids ) ) {
 			return array();
 		}
-		
-		$course_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"
-					SELECT mp.page_id 
-					FROM $wpdb->pmpro_memberships_pages mp 
-					LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
-					WHERE mp.membership_id IN(%s) 
-					AND p.post_type = 'sfwd-courses' 
-					AND p.post_status = 'publish' 
-					GROUP BY mp.page_id
-				",
-				implode(',', $level_ids )
-			)
-		);
+
+		$sql = "
+			SELECT mp.page_id 
+			FROM $wpdb->pmpro_memberships_pages mp 
+			LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
+			WHERE mp.membership_id IN(".implode(', ', array_fill(0, count($level_ids), '%s')).") 
+			AND p.post_type = 'sfwd-courses' 
+			AND p.post_status = 'publish' 
+			GROUP BY mp.page_id
+		";
+		$course_ids = $wpdb->get_col( call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $level_ids ) ) );
 
 		return $course_ids;
 	}

--- a/includes/modules/lifterlms.php
+++ b/includes/modules/lifterlms.php
@@ -101,20 +101,16 @@ class PMPro_Courses_LifterLMS extends PMPro_Courses_Module {
 			return array();
 		}
 		
-		$course_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"
-					SELECT mp.page_id 
-					FROM $wpdb->pmpro_memberships_pages mp 
-					LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
-					WHERE mp.membership_id IN(%s) 
-					AND p.post_type = 'course' 
-					AND p.post_status = 'publish' 
-					GROUP BY mp.page_id
-				",
-				implode(',', $level_ids )
-			)
-		);
+		$sql = "
+			SELECT mp.page_id 
+			FROM $wpdb->pmpro_memberships_pages mp 
+			LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
+			WHERE mp.membership_id IN(".implode(', ', array_fill(0, count($level_ids), '%s')).") 
+			AND p.post_type = 'course' 
+			AND p.post_status = 'publish' 
+			GROUP BY mp.page_id
+		";
+		$course_ids = $wpdb->get_col( call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $level_ids ) ) );
 		
 		return $course_ids;
 	}

--- a/includes/modules/senseilms.php
+++ b/includes/modules/senseilms.php
@@ -237,20 +237,16 @@ class PMPro_Courses_SenseiLMS extends PMPro_Courses_Module {
 			return array();
 		}
 
-		$course_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"
-					SELECT mp.page_id 
-					FROM $wpdb->pmpro_memberships_pages mp 
-					LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
-					WHERE mp.membership_id IN(%s) 
-					AND p.post_type = 'course' 
-					AND p.post_status = 'publish' 
-					GROUP BY mp.page_id
-				",
-				implode( ',', $level_ids )
-			)
-		);
+		$sql = "
+			SELECT mp.page_id 
+			FROM $wpdb->pmpro_memberships_pages mp 
+			LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
+			WHERE mp.membership_id IN(".implode(', ', array_fill(0, count($level_ids), '%s')).") 
+			AND p.post_type = 'course' 
+			AND p.post_status = 'publish' 
+			GROUP BY mp.page_id
+		";
+		$course_ids = $wpdb->get_col( call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $level_ids ) ) );
 
 		return $course_ids;
 	}

--- a/includes/modules/tutorlms.php
+++ b/includes/modules/tutorlms.php
@@ -241,20 +241,16 @@ class PMPro_Courses_TutorLMS extends PMPro_Courses_Module {
 			return array();
 		}
 		
-		$course_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"
-					SELECT mp.page_id 
-					FROM $wpdb->pmpro_memberships_pages mp 
-					LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
-					WHERE mp.membership_id IN(%s) 
-					AND p.post_type = 'courses' 
-					AND p.post_status = 'publish' 
-					GROUP BY mp.page_id
-				",
-				implode(',', $level_ids )
-			)
-		);		
+		$sql = "
+			SELECT mp.page_id 
+			FROM $wpdb->pmpro_memberships_pages mp 
+			LEFT JOIN $wpdb->posts p ON mp.page_id = p.ID 
+			WHERE mp.membership_id IN(".implode(', ', array_fill(0, count($level_ids), '%s')).") 
+			AND p.post_type = 'courses' 
+			AND p.post_status = 'publish' 
+			GROUP BY mp.page_id
+		";
+		$course_ids = $wpdb->get_col( call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $level_ids ) ) );
 		
 		return $course_ids;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, the `prepare()` statements below were creating level checks like `WHERE mp.membership_id IN('1,2,3')` instead of like `WHERE mp.membership_id IN('1','2','3')`. This PR keeps the prepare statements for security, but fixes cases with MMPU where courses may not be enrolled/unenrolled correctly when the user has multiple levels.

Resolves #55

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
