### PR TITLE
Change h3 tags to h2 

### DIFF
--- a/includes/adminpages/settings.php
+++ b/includes/adminpages/settings.php
@@ -6,7 +6,7 @@
 	</h1>
 	<p><?php esc_html_e( 'Which modules would you like to enable?', 'pmpro-courses' ); ?></p>
 	<form method='POST'>
-		<h3><?php esc_html_e( 'Modules', 'pmpro-courses' );?></h3>
+		<h2><?php esc_html_e( 'Modules', 'pmpro-courses' );?></h2>
 		<table class='form-table pmpro-courses'>	
 		<?php
 			$modules = pmpro_courses_get_modules();            

--- a/includes/common.php
+++ b/includes/common.php
@@ -214,7 +214,7 @@ function pmpro_courses_get_lessons_html( $course_id ) {
 	// Build the HTML to output a list of lessons.
 	?>
 	<div class="pmpro_courses pmpro_courses-lessons <?php echo esc_attr( $pmpro_courses_lesson_access_class ); ?>">
-		<h3 class="pmpro_courses-title"><?php esc_html_e( 'Lessons', 'pmpro-courses' ); ?></h3>
+		<h2 class="pmpro_courses-title"><?php esc_html_e( 'Lessons', 'pmpro-courses' ); ?></h2>
 		<ol class="pmpro_courses-list">
 			<?php
 				foreach( $lessons as $lesson ) { ?>

--- a/includes/post-types/courses.php
+++ b/includes/post-types/courses.php
@@ -111,7 +111,7 @@ function pmpro_courses_course_cpt_lessons() {
 			</tbody>
 		</table>
 
-		<h3><?php esc_html_e( 'Add Lessons', 'pmpro-courses' ); ?></h3>
+		<h2><?php esc_html_e( 'Add Lessons', 'pmpro-courses' ); ?></h2>
 		<table id="newmeta" class="wp-list-table pmpro-metabox-items">
 			<tbody>
 				<tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes all h3 tags to h2 for a11y
