### PR TITLE
Swapping the lessons list for a course to use the course ID so it can be used on the single lesson page also

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -232,7 +232,7 @@ function pmpro_courses_get_lessons_html( $course_id ) {
 							<?php
 								if ( is_user_logged_in() && ! empty( $hasaccess ) ) {
 									// Get the status of this lesson.
-									$lesson_status = pmpro_courses_get_user_lesson_status( $lesson->ID, $post->ID, get_current_user_id() );
+									$lesson_status = pmpro_courses_get_user_lesson_status( $lesson->ID, $course_id, get_current_user_id() );
 									if ( ! empty( $lesson_status ) ) {
 										if ( $lesson_status === 'complete' ) {
 											echo '<span class="pmpro_courses-lesson-status pmpro_courses-lesson-status-complete"><i class="dashicons dashicons-yes"></i><span class="pmpro_courses-lesson-status-label">' . esc_html( 'Complete', 'pmpro-courses' ) . '</span></span>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The function that shows the lesson list for a single course (including whether its completed or not) works great on the single course page (in the context of that global $post / $post->ID.

I wanted to use this same function to output the lesson list on a lesson within the course - but the status of whether it was complete wasn't showing.

This change should not affect any functionality and only opens it up to checking the context of the passed $course_id which is already a requirement of rendering the output anyway.

### How to test the changes in this Pull Request:

1. Add the function to output the lessons html to a single lesson template file: `echo pmpro_courses_get_lessons_html( $post->post_parent );`
2. without the change, the status of whether lessons are complete is not available.
3. with the change, the correct lesson status is shown in the list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Now using $course_id in outputting lesson list in the context of a specific course.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
