### PR TITLE
Fix warning on Courses CPT "Level" column if the level found doesn't have a name (probably deleted)

### DIFF
--- a/includes/courses.php
+++ b/includes/courses.php
@@ -157,7 +157,9 @@ function pmpro_courses_columns_content( $column, $course_id ) {
 			$level_names = array();
 			foreach ( $course_levels as $id ) {
 				$level = pmpro_getLevel( $id );
-				$level_names[] = $level->name;
+				if ( ! empty( $level->id ) ) {
+					$level_names[] = $level->name;
+				}
 			}
 			if ( ! empty( $level_names ) ) {
 				echo implode( ', ', $level_names );

--- a/includes/courses.php
+++ b/includes/courses.php
@@ -157,7 +157,7 @@ function pmpro_courses_columns_content( $column, $course_id ) {
 			$level_names = array();
 			foreach ( $course_levels as $id ) {
 				$level = pmpro_getLevel( $id );
-				if ( ! empty( $level->id ) ) {
+				if ( ! empty( $level->name ) ) {
 					$level_names[] = $level->name;
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
There was a warning shown for levels without a "name" (probably because they were deleted) on the All Courses CPT screen in the WP Admin. This fix checks that there is an existing level name, then adds to the array.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed warning in Levels column of the All Courses screen in WP admin.
 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
