### PR TITLE
Removed unused code to stop always showing a blank warning in Classic Editor.

### DIFF
--- a/includes/post-types/courses.php
+++ b/includes/post-types/courses.php
@@ -97,7 +97,6 @@ function pmpro_courses_course_cpt_lessons() {
 			return false;
 		}
 		?>	
-		<div class="message error"><p><?php //echo $this->error; ?></p></div>
 		<table id="pmpro_courses_table" class="wp-list-table widefat striped pmpro-metabox-items">
 			<thead>
 				<th><?php esc_html_e( 'Order', 'pmpro-courses' ); ?></th>


### PR DESCRIPTION
* BUG FIX: Fixes an issue with the classic editor showing an error always. This code was never used so removed it.

Before:
<img width="1090" alt="Screenshot 2025-06-17 at 10 35 25" src="https://github.com/user-attachments/assets/f1b3805f-6e69-4603-a504-a9eef5a0deda" />

After:
<img width="1143" alt="Screenshot 2025-06-17 at 10 35 34" src="https://github.com/user-attachments/assets/47560cab-b396-44c1-8973-80dbc96456af" />

This code was never used, it's safe to remove it.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

### How to test the changes in this Pull Request:

1. Load the latest version of the Courses Add On in Classic Editor mode. See the warning.
2. Apply this PR.
3. Reload the page and see that the error warning isn't there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
