### PR TITLE
Add Course structured data (JSON-LD) for default module

### DIFF
--- a/includes/modules/default.php
+++ b/includes/modules/default.php
@@ -104,7 +104,8 @@ class PMPro_Courses_Module {
         require_once PMPRO_COURSES_DIR . '/includes/shortcodes/all-courses.php';
         require_once PMPRO_COURSES_DIR . '/includes/shortcodes/my-courses.php';
 		require_once PMPRO_COURSES_DIR . '/includes/shortcodes/courses-outline.php';
-                
+		require_once PMPRO_COURSES_DIR . '/includes/structured-data.php';
+
         add_filter( 'pmpro_membership_content_filter', 'pmpro_courses_show_course_content_and_lessons', 10, 2 );
         add_filter( 'the_content', 'pmpro_courses_add_lessons_to_course' );
 		add_filter( 'pmpro_member_edit_panels', array( PMPro_Courses_Module::class, 'pmpro_courses_pmpro_member_edit_panels' ) );

--- a/includes/structured-data.php
+++ b/includes/structured-data.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Structured data (JSON-LD) for the default Courses module.
+ * Outputs Course schema on single course pages and ItemList schema
+ * on the CPT archive and pages using the [pmpro_all_courses] shortcode.
+ *
+ * @since 1.3
+ */
+
+/**
+ * Output Course JSON-LD structured data on single course pages.
+ *
+ * @since 1.3
+ */
+function pmpro_courses_structured_data_single() {
+	if ( ! is_singular( 'pmpro_course' ) ) {
+		return;
+	}
+
+	$post = get_post();
+	if ( empty( $post ) ) {
+		return;
+	}
+
+	$schema = pmpro_courses_build_course_schema( $post );
+
+	?>
+	<script type="application/ld+json">
+	<?php echo wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ); ?>
+	</script>
+	<?php
+}
+add_action( 'wp_head', 'pmpro_courses_structured_data_single' );
+
+/**
+ * Output ItemList JSON-LD structured data on course listing pages.
+ * Fires on the CPT archive and on pages containing the [pmpro_all_courses] shortcode.
+ *
+ * @since 1.3
+ */
+function pmpro_courses_structured_data_listing() {
+	// CPT archive.
+	$is_archive = is_post_type_archive( 'pmpro_course' );
+
+	// Page with [pmpro_all_courses] shortcode.
+	$is_shortcode_page = false;
+	if ( is_page() ) {
+		$post = get_post();
+		if ( ! empty( $post ) && has_shortcode( $post->post_content, 'pmpro_all_courses' ) ) {
+			$is_shortcode_page = true;
+		}
+	}
+
+	if ( ! $is_archive && ! $is_shortcode_page ) {
+		return;
+	}
+
+	$courses = pmpro_courses_get_courses();
+	if ( empty( $courses ) ) {
+		return;
+	}
+
+	$item_list_elements = array();
+	$position           = 1;
+
+	foreach ( $courses as $course ) {
+		$item_list_elements[] = array(
+			'@type'    => 'ListItem',
+			'position' => $position,
+			'url'      => get_permalink( $course->ID ),
+			'item'     => pmpro_courses_build_course_schema( $course ),
+		);
+		$position++;
+	}
+
+	$schema = array(
+		'@context'        => 'https://schema.org',
+		'@type'           => 'ItemList',
+		'itemListElement' => $item_list_elements,
+	);
+
+	?>
+	<script type="application/ld+json">
+	<?php echo wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ); ?>
+	</script>
+	<?php
+}
+add_action( 'wp_head', 'pmpro_courses_structured_data_listing' );
+
+/**
+ * Build a Course schema array for a given course post.
+ *
+ * @since 1.3
+ * @param WP_Post $course The course post object.
+ * @return array Course schema array.
+ */
+function pmpro_courses_build_course_schema( $course ) {
+	// Description: excerpt first, fallback to trimmed content.
+	$description = $course->post_excerpt;
+	if ( empty( $description ) ) {
+		$description = wp_trim_words( $course->post_content, 20, '...' );
+	}
+
+	/**
+	 * Filter the provider organization data for Course structured data.
+	 *
+	 * @since 1.3
+	 * @param array   $provider {
+	 *     Provider organization schema.
+	 *     @type string $@type  Schema type. Default 'Organization'.
+	 *     @type string $name   Organization name. Default site name.
+	 *     @type string $sameAs Organization URL. Default home URL.
+	 * }
+	 * @param WP_Post $course The course post object.
+	 */
+	$provider = apply_filters(
+		'pmpro_courses_structured_data_provider',
+		array(
+			'@type'  => 'Organization',
+			'name'   => get_bloginfo( 'name' ),
+			'sameAs' => home_url(),
+		),
+		$course
+	);
+
+	$schema = array(
+		'@context'    => 'https://schema.org',
+		'@type'       => 'Course',
+		'name'        => get_the_title( $course->ID ),
+		'description' => wp_strip_all_tags( $description ),
+		'url'         => get_permalink( $course->ID ),
+		'provider'    => $provider,
+	);
+
+	/**
+	 * Filter the full Course schema array.
+	 *
+	 * @since 1.3
+	 * @param array   $schema The Course schema array.
+	 * @param WP_Post $course The course post object.
+	 */
+	return apply_filters( 'pmpro_courses_structured_data_schema', $schema, $course );
+}

--- a/includes/structured-data.php
+++ b/includes/structured-data.php
@@ -46,7 +46,7 @@ function pmpro_courses_structured_data_listing() {
 	$is_shortcode_page = false;
 	if ( is_page() ) {
 		$post = get_post();
-		if ( ! empty( $post ) && has_shortcode( $post->post_content, 'pmpro_all_courses' ) ) {
+		if ( ! empty( $post ) && ( has_shortcode( $post->post_content, 'pmpro_all_courses' ) || has_block( 'pmpro-courses/all-courses', $post ) ) ) {
 			$is_shortcode_page = true;
 		}
 	}

--- a/includes/structured-data.php
+++ b/includes/structured-data.php
@@ -4,13 +4,13 @@
  * Outputs Course schema on single course pages and ItemList schema
  * on the CPT archive and pages using the [pmpro_all_courses] shortcode.
  *
- * @since 1.3
+ * @since TBD
  */
 
 /**
  * Output Course JSON-LD structured data on single course pages.
  *
- * @since 1.3
+ * @since TBD
  */
 function pmpro_courses_structured_data_single() {
 	if ( ! is_singular( 'pmpro_course' ) ) {
@@ -26,7 +26,7 @@ function pmpro_courses_structured_data_single() {
 
 	?>
 	<script type="application/ld+json">
-	<?php echo wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ); ?>
+	<?php echo wp_json_encode( $schema, JSON_PRETTY_PRINT ); ?>
 	</script>
 	<?php
 }
@@ -36,7 +36,7 @@ add_action( 'wp_head', 'pmpro_courses_structured_data_single' );
  * Output ItemList JSON-LD structured data on course listing pages.
  * Fires on the CPT archive and on pages containing the [pmpro_all_courses] shortcode.
  *
- * @since 1.3
+ * @since TBD
  */
 function pmpro_courses_structured_data_listing() {
 	// CPT archive.
@@ -81,7 +81,7 @@ function pmpro_courses_structured_data_listing() {
 
 	?>
 	<script type="application/ld+json">
-	<?php echo wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ); ?>
+	<?php echo wp_json_encode( $schema, JSON_PRETTY_PRINT ); ?>
 	</script>
 	<?php
 }
@@ -90,7 +90,7 @@ add_action( 'wp_head', 'pmpro_courses_structured_data_listing' );
 /**
  * Build a Course schema array for a given course post.
  *
- * @since 1.3
+ * @since TBD
  * @param WP_Post $course The course post object.
  * @return array Course schema array.
  */
@@ -104,7 +104,7 @@ function pmpro_courses_build_course_schema( $course ) {
 	/**
 	 * Filter the provider organization data for Course structured data.
 	 *
-	 * @since 1.3
+	 * @since TBD
 	 * @param array   $provider {
 	 *     Provider organization schema.
 	 *     @type string $@type  Schema type. Default 'Organization'.
@@ -135,7 +135,7 @@ function pmpro_courses_build_course_schema( $course ) {
 	/**
 	 * Filter the full Course schema array.
 	 *
-	 * @since 1.3
+	 * @since TBD
 	 * @param array   $schema The Course schema array.
 	 * @param WP_Post $course The course post object.
 	 */


### PR DESCRIPTION
## Summary
- Adds Google Search Course structured data support to the default module
- Outputs `Course` schema on single course pages
- Outputs `ItemList` schema on the CPT archive and pages with `[pmpro_all_courses]` shortcode

## Implementation
**New file:** `includes/structured-data.php`
- `pmpro_courses_structured_data_single()` — outputs Course JSON-LD on `wp_head` for single course pages
- `pmpro_courses_structured_data_listing()` — outputs ItemList JSON-LD on course listing pages (archive + shortcode)
- `pmpro_courses_build_course_schema()` — builds Course schema array (reusable for both contexts)

**Modified:** `includes/modules/default.php`
- Added `require_once` for the new structured-data.php file in `init_active()`

## Filters
Two new filters for developer customization:
1. **`pmpro_courses_structured_data_provider`** — Filter the provider organization data
2. **`pmpro_courses_structured_data_schema`** — Filter the full Course schema array

## Google Requirements
Satisfies Google's Course structured data requirements:
- Required: `name`, `description`
- Recommended: `provider` (Organization)
- Listing pages: `ItemList` wrapper with `position` and `url`

## Test Plan
1. Enable the default module in PMPro Courses settings
2. Create 3+ test courses with titles and descriptions
3. Visit a single course page → view source → verify `Course` JSON-LD is present
4. Visit the `/courses/` archive → view source → verify `ItemList` JSON-LD is present with all courses
5. Create a page with `[pmpro_all_courses]` → verify `ItemList` JSON-LD is present
6. Test with Google's Rich Results Test: https://search.google.com/test/rich-results

Generated with [Claude Code](https://claude.com/claude-code)